### PR TITLE
Fix camera image topics and optical frame IDs

### DIFF
--- a/launch/apriltag_detector.launch.py
+++ b/launch/apriltag_detector.launch.py
@@ -20,7 +20,7 @@ def generate_launch_description():
                 'image_width': 800,
                 'image_height': 600,
                 'focal_length': 600.0,
-                'frame_id': 'camera_link'
+                'frame_id': 'camera_link_optical_frame'
             }],
             output='screen'
         ),

--- a/launch/nav2_bt_real_robot.launch.py
+++ b/launch/nav2_bt_real_robot.launch.py
@@ -46,7 +46,7 @@ def generate_launch_description():
         parameters=[{
             'camera_info_url': 'package://shelfbot/config/camera_info.yaml',
             'camera_name': 'camera',
-            'frame_id': 'camera_link',
+            'frame_id': 'camera_link_optical_frame',
             'use_sim_time': False
         }],
         output='screen'

--- a/launch/nav2_orb_slam3.launch.py
+++ b/launch/nav2_orb_slam3.launch.py
@@ -32,7 +32,7 @@ def generate_launch_description():
         parameters=[{
             'camera_info_url': os.path.join(shelfbot_share_dir, 'config', 'package://shelfbot/config/camera_info.yaml'),
             'camera_name': 'esp32_cam',
-            'frame_id': 'camera_link',
+            'frame_id': 'camera_link_optical_frame',
             'image_width': 800,
             'image_height': 600,
             'focal_length': 600.0,   # unified intrinsics: match the working AprilTag setup
@@ -76,7 +76,7 @@ def generate_launch_description():
             'settings_file': os.path.join(shelfbot_share_dir, 'config', 'orb_slam3_monocular.yaml'),
             'camera_topic': '/camera/image_raw',
             'camera_info_topic': '/camera/camera_info',
-            'camera_frame': 'camera_link',
+            'camera_frame': 'camera_link_optical_frame',
             'map_frame': 'map',
             'odom_frame': 'odom',
             'base_link_frame': 'base_link',

--- a/launch/real_robot_hardened_lidar_microros.launch.py
+++ b/launch/real_robot_hardened_lidar_microros.launch.py
@@ -22,10 +22,6 @@ def generate_launch_description():
     lidar_x, lidar_y, lidar_z         = '0.0', '0.0', '0.2'
     lidar_roll, lidar_pitch, lidar_yaw = '0.0', '0.0', '0.0'
 
-    # ── Camera mount (tweak to match your physical setup) ──────────────────────
-    camera_x, camera_y, camera_z         = '0.1', '0.0', '0.15'
-    camera_roll, camera_pitch, camera_yaw = '0.0', '0.0', '0.0'
-
     # ── Robot description ──────────────────────────────────────────────────────
     doc = xacro.process_file(xacro_file, mappings={'communication_type': 'microros'})
     robot_description = {'robot_description': doc.toxml()}
@@ -71,20 +67,6 @@ def generate_launch_description():
         parameters=[{'use_sim_time': False}],
     )
 
-    # Static TF: base_link → camera_frame
-    # Required so RViz and Nav2 can project the image into the robot frame.
-    static_tf_camera = Node(
-        package='tf2_ros',
-        executable='static_transform_publisher',
-        name='static_tf_camera',
-        arguments=[
-            camera_x, camera_y, camera_z,
-            camera_roll, camera_pitch, camera_yaw,
-            'base_link', 'camera_frame',
-        ],
-        parameters=[{'use_sim_time': False}],
-    )
-
     # Lidar relay: /shelfbot_firmware/laser_scan → /scan (360° accumulator)
     lidar_relay = Node(
         package='shelfbot',
@@ -100,20 +82,26 @@ def generate_launch_description():
         respawn_delay=2.0,
     )
 
-    # Camera republisher: /camera/compressed (CompressedImage) → /camera/raw (Image)
-    # RViz's Image display requires a raw sensor_msgs/Image topic; it cannot
-    # decode CompressedImage natively. image_transport's republish node does
-    # the JPEG decompression so RViz gets a plain RGB frame.
-    camera_republisher = Node(
-        package='image_transport',
-        executable='republish',
-        name='camera_republisher',
-        arguments=['compressed', 'raw'],
-        remappings=[
-            ('in/compressed', '/camera/compressed'),
-            ('out',           '/camera/raw'),
-        ],
-        parameters=[{'use_sim_time': False}],
+    # Camera bridge: /camera/compressed (CompressedImage) → /camera/image_raw
+    # (Image) + /camera/camera_info.  It also overwrites the firmware-provided
+    # camera_frame header with the URDF optical frame so TF, RViz, AprilTag, and
+    # visual odometry all use the same camera frame.
+    camera_publisher = Node(
+        package='shelfbot',
+        executable='camera_publisher',
+        name='camera_publisher',
+        output='screen',
+        parameters=[{
+            'camera_info_url': 'package://shelfbot/config/camera_info.yaml',
+            'camera_name': 'esp32_cam',
+            'frame_id': 'camera_link_optical_frame',
+            'compressed_image_topic': '/camera/compressed',
+            'image_topic': '/camera/image_raw',
+            'camera_info_topic': '/camera/camera_info',
+            'image_width': 800,
+            'image_height': 600,
+            'use_sim_time': False,
+        }],
         respawn=True,
         respawn_delay=2.0,
     )
@@ -170,7 +158,7 @@ def generate_launch_description():
     # immediately rather than showing everything grey/unknown.
     #
     # In RViz add:
-    #   • Image display  → topic: /camera/raw
+    #   • Image display  → topic: /camera/image_raw
     #   • LaserScan      → topic: /scan
     # ══════════════════════════════════════════════════════════════════════════
 
@@ -193,9 +181,8 @@ def generate_launch_description():
         robot_state_pub,
         control_node,
         static_tf_lidar,
-        static_tf_camera,
         lidar_relay,
-        camera_republisher,
+        camera_publisher,
         # Tier 2 – controllers (t=3 s)
         delay_controllers,
         # Tier 3 – Nav2 (t=8 s)

--- a/launch/shelfbot.launch.py
+++ b/launch/shelfbot.launch.py
@@ -46,7 +46,7 @@ def generate_launch_description():
         parameters=[{
             'camera_info_url': 'package://shelfbot/config/camera_info.yaml',
             'camera_name': 'camera',
-            'frame_id': 'camera_link',
+            'frame_id': 'camera_link_optical_frame',
             'use_sim_time': False
         }],
         output='screen'

--- a/src/nodes/camera_publisher.cpp
+++ b/src/nodes/camera_publisher.cpp
@@ -18,30 +18,39 @@ public:
     this->declare_parameter<int>   ("image_width",    800);
     this->declare_parameter<int>   ("image_height",   600);
     this->declare_parameter<double>("focal_length",   800.0);
+    this->declare_parameter<std::string>("compressed_image_topic",
+                                         "/camera/compressed");
+    this->declare_parameter<std::string>("image_topic",
+                                         "/camera/image_raw");
+    this->declare_parameter<std::string>("camera_info_topic",
+                                         "/camera/camera_info");
 
     std::string camera_info_url;
-    this->get_parameter("camera_info_url", camera_info_url);
-    this->get_parameter("camera_name",     camera_name_);
-    this->get_parameter("frame_id",        frame_id_);
-    this->get_parameter("image_width",     image_width_);
-    this->get_parameter("image_height",    image_height_);
-    this->get_parameter("focal_length",    focal_length_);
+    this->get_parameter("camera_info_url",       camera_info_url);
+    this->get_parameter("camera_name",           camera_name_);
+    this->get_parameter("frame_id",              frame_id_);
+    this->get_parameter("image_width",           image_width_);
+    this->get_parameter("image_height",          image_height_);
+    this->get_parameter("focal_length",          focal_length_);
+    this->get_parameter("compressed_image_topic", compressed_image_topic_);
+    this->get_parameter("image_topic",           image_topic_);
+    this->get_parameter("camera_info_topic",     camera_info_topic_);
 
     info_manager_ = std::make_shared<camera_info_manager::CameraInfoManager>(
         this, camera_name_, camera_info_url);
 
     image_publisher_ = this->create_publisher<sensor_msgs::msg::Image>(
-        "camera/image_raw",
-        rclcpp::QoS(rclcpp::KeepLast(10)).reliable());
+        image_topic_,
+        rclcpp::SensorDataQoS());
 
     info_publisher_ = this->create_publisher<sensor_msgs::msg::CameraInfo>(
-        "camera/camera_info",
-        rclcpp::QoS(rclcpp::KeepLast(10)).reliable());
+        camera_info_topic_,
+        rclcpp::SensorDataQoS());
 
-    // Subscribe to compressed images from micro-ROS / ESP32-CAM
+    // Subscribe to compressed images from micro-ROS / ESP32-CAM.
     compressed_image_sub_ =
         this->create_subscription<sensor_msgs::msg::CompressedImage>(
-            "/esp32_cam/image_raw/compressed",
+            compressed_image_topic_,
             rclcpp::SensorDataQoS(),
             std::bind(&CameraPublisher::image_callback, this,
                       std::placeholders::_1));
@@ -51,9 +60,10 @@ public:
                 image_width_, image_height_);
     RCLCPP_INFO(this->get_logger(), "  Frame ID   : %s", frame_id_.c_str());
     RCLCPP_INFO(this->get_logger(),
-                "  Subscribing: /esp32_cam/image_raw/compressed");
+                "  Subscribing: %s", compressed_image_topic_.c_str());
     RCLCPP_INFO(this->get_logger(),
-                "  Publishing : camera/image_raw, camera/camera_info");
+                "  Publishing : %s, %s", image_topic_.c_str(),
+                camera_info_topic_.c_str());
   }
 
 private:
@@ -165,6 +175,9 @@ private:
 
   std::string camera_name_;
   std::string frame_id_;
+  std::string compressed_image_topic_;
+  std::string image_topic_;
+  std::string camera_info_topic_;
   int         image_width_;
   int         image_height_;
   double      focal_length_;

--- a/src/nodes/shelfbot_slam_orb3_node.cpp
+++ b/src/nodes/shelfbot_slam_orb3_node.cpp
@@ -7,7 +7,7 @@ ShelfbotORB3Node::ShelfbotORB3Node(const rclcpp::NodeOptions & opts) : Node("she
   declare_parameter<std::string>("settings_file", "/home/chris/shelfbot_workspace/src/shelfbot/config/orb_slam3_monocular.yaml");
   declare_parameter<std::string>("camera_topic", "/camera/image_raw");
   declare_parameter<std::string>("camera_info_topic", "/camera/camera_info");
-  declare_parameter<std::string>("camera_frame", "camera_link");
+  declare_parameter<std::string>("camera_frame", "camera_link_optical_frame");
   declare_parameter<std::string>("map_frame", "map");
   declare_parameter<std::string>("odom_frame", "odom");
   declare_parameter<std::string>("base_link_frame", "base_link");


### PR DESCRIPTION
### Motivation
- RViz and perception nodes were not receiving images and TFs because the firmware frame (`camera_frame`) did not match the URDF (`camera_link` / `camera_link_optical_frame`), and the hardened launch introduced a synthetic `base_link -> camera_frame` static TF that conflicted with the URDF.
- The objective is to ensure a single authoritative pipeline: decode compressed images, publish `sensor_msgs/Image` + `sensor_msgs/CameraInfo` stamped with the URDF optical frame, and remove conflicting synthetic TFs so TF, AprilTag, and VO/SLAM all agree.

### Description
- Replaced the `image_transport republish` usage in the hardened real-robot launch with the package `camera_publisher` bridge that decompresses the camera feed and also publishes camera info, and removed the synthetic `static_tf_camera` node so the URDF/`robot_state_publisher` is the single TF source.
- Parameterized `camera_publisher` with `compressed_image_topic`, `image_topic`, and `camera_info_topic` so input/output topics are configurable and no longer hardcoded to the old firmware-only names, and the node stamps both image and camera_info with the configured `frame_id`.
- Standardized the optical frame across launches and SLAM: switched launch default parameters to use `camera_link_optical_frame` (updated `launch/nav2_orb_slam3.launch.py`, `launch/apriltag_detector.launch.py`, `launch/nav2_bt_real_robot.launch.py`, `launch/shelfbot.launch.py`, and the hardened launch), and updated the SLAM node default `camera_frame` to `camera_link_optical_frame`.
- Implementation touches: `launch/real_robot_hardened_lidar_microros.launch.py` (remove static camera TF + use `camera_publisher`), `src/nodes/camera_publisher.cpp` (add topic params and use configured topics/QoS), and multiple launch files to align `frame_id` to the URDF optical frame.

### Testing
- Ran `python3 -m py_compile launch/*.launch.py` to validate launch file syntax, which succeeded without errors.
- Ran `git diff --check` to detect whitespace/merge issues, which returned clean results.
- Attempted a local package build with `colcon build --packages-select shelfbot --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo` but it was not executed in this environment because `/opt/ros/humble/setup.bash` was not present, so a full build/test could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d9e423d7c83229bc944d5f7efbc8a)