### PR TITLE
Align lidar frame with robot front

### DIFF
--- a/launch/real_robot_nav2.launch.py
+++ b/launch/real_robot_nav2.launch.py
@@ -105,8 +105,8 @@ def generate_launch_description():
     # ══════════════════════════════════════════════════════════════════════════
     # TIER 4  (t=7 s) – slam_toolbox
     #
-    # Delayed after EKF so slam_toolbox's first scan lookup finds a valid
-    # odom→base_footprint TF in the EKF's buffer, not the raw odometry's.
+    # Delayed until the hardware odometry publisher has produced a valid
+    # odom→base_footprint TF for slam_toolbox's first scan lookup.
     # ══════════════════════════════════════════════════════════════════════════
 
     slam_toolbox = IncludeLaunchDescription(

--- a/urdf/lidar_sensor.xacro
+++ b/urdf/lidar_sensor.xacro
@@ -2,8 +2,10 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <!--
     Minimal laser_link for the LYDSTO LDS02RR lidar.
-    Mounted flat on top of base_link, centred, facing up.
-    Adjust xyz/rpy to match physical placement.
+    Mounted flat with the scan plane parallel to the floor.  Per REP 103,
+    LaserScan angle 0 is along laser_link +X and positive angles rotate toward
+    +Y.  The mounting joint in shelfbot.urdf.xacro is responsible for placing
+    +X along the robot's physical forward direction.
   -->
   <xacro:macro name="lidar_sensor" params="name">
     <link name="${name}">

--- a/urdf/shelfbot.urdf.xacro
+++ b/urdf/shelfbot.urdf.xacro
@@ -186,10 +186,14 @@
 
   <xacro:lidar_sensor name="laser_link"/>
 
+  <!-- The physical robot front is base_link +Y (mapped to base_footprint +X by
+       joint_base_footprint's -pi/2 yaw).  LaserScan angle 0 is laser_link +X,
+       so yaw laser_link +90 deg relative to base_link and place it at the
+       front tip of the chassis. -->
   <joint name="joint_laser" type="fixed">
     <parent link="base_link"/>
     <child link="laser_link"/>
-    <origin xyz="0 0 ${base_height}" rpy="0 0 0"/>
+    <origin xyz="0 ${base_length/2} ${base_height}" rpy="0 0 ${pi/2}"/>
   </joint>
 
   <!-- ── Ultrasonic sensors (3 front, 3 back) ──────────────────────── -->


### PR DESCRIPTION
### Motivation

- The lidar scan frame was not aligned with the robot's forward direction because `base_link` is yawed `-pi/2` relative to `base_footprint`, causing `laser_link` +X (LaserScan angle 0) to point incorrectly and producing conflicting `map`/`odom`/`base` TFs in RViz when both SLAM and odometry were active. 

### Description

- Update `urdf/shelfbot.urdf.xacro` to move the `laser_link` joint to the front tip at `xyz="0 ${base_length/2} ${base_height}"` and rotate it by `rpy="0 0 ${pi/2}"` so `laser_link +X` aligns with robot-forward in `base_footprint`.
- Clarify the lidar mounting convention and REP 103 LaserScan angle directions in `urdf/lidar_sensor.xacro` so the model matches scan angle semantics.
- Tidy an explanatory comment in `launch/real_robot_nav2.launch.py` to avoid a stale EKF wording and reflect that slam_toolbox must wait for the hardware odometry `odom->base_footprint` TF.
- Files changed: `urdf/shelfbot.urdf.xacro`, `urdf/lidar_sensor.xacro`, and `launch/real_robot_nav2.launch.py`.

### Testing

- Ran a transform sanity check script (`python3 - <<'PY' ... PY`) that verified `laser_link +X` maps to `base_footprint +X` and the lidar origin maps to the front of the chassis, and it succeeded.
- Compiled the launch file with `python3 -m py_compile launch/real_robot_nav2.launch.py` and it succeeded.
- Ran `git diff --check` to ensure no whitespace/merge issues and it reported no problems.
- Attempted full Xacro expansion and XML linting but the container lacked the `xacro` Python module and `xmllint`, so those checks could not be run here (warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4276abffe083228cc7fccf0abd3f1c)